### PR TITLE
Add modeless support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 **/package-lock.json
 **/bower_components/
 /.settings/
+.classpath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.vaadin.componentfactory</groupId>
 	<artifactId>popup-root</artifactId>
 	<packaging>pom</packaging>
-	<version>2.2.5</version>
+	<version>2.2.6-SNAPSHOT</version>
 
 	<name>Popup Root</name>
 

--- a/popup-demo/pom.xml
+++ b/popup-demo/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <vaadin.version>14.5.4</vaadin.version>
-        <flow.version>2.4.0</flow.version>
+        <vaadin.version>14.10.8</vaadin.version>
+        <flow.version>2.9.9</flow.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.4.11.v20180605</version>
+                <version>9.4.36.v20210114</version>
                 <configuration>
                     <scanIntervalSeconds>1</scanIntervalSeconds>
                 </configuration>

--- a/popup-demo/pom.xml
+++ b/popup-demo/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>popup-demo</artifactId>
     <packaging>war</packaging>
-    <version>2.2.5</version>
+    <version>2.2.6-SNAPSHOT</version>
 
     <name>Popup Demo</name>
 

--- a/popup/pom.xml
+++ b/popup/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>popup</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.5</version>
+    <version>2.2.6-SNAPSHOT</version>
 
     <name>Popup</name>
 

--- a/popup/pom.xml
+++ b/popup/pom.xml
@@ -18,16 +18,12 @@
 
 
     <properties>
-        <vaadin.version>14.5.4</vaadin.version>
-
+        <vaadin.version>14.10.8</vaadin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
         <drivers.dir>${project.basedir}/drivers</drivers.dir>
-
-        <jetty.version>9.4.15.v20190215</jetty.version>
     </properties>
 
     <dependencyManagement>

--- a/popup/src/main/java/com/vaadin/componentfactory/Popup.java
+++ b/popup/src/main/java/com/vaadin/componentfactory/Popup.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * @author Vaadin Ltd
  */
 @Tag("vcf-popup")
-@NpmPackage(value = "@vaadin-component-factory/vcf-popup", version = "1.2.6")
+@NpmPackage(value = "@vaadin-component-factory/vcf-popup", version = "1.2.8")
 @JsModule("./flow-component-renderer.js")
 @JsModule("@vaadin-component-factory/vcf-popup/src/vcf-popup.js")
 public class Popup extends PolymerTemplate<Popup.PopupModel> {
@@ -251,6 +251,23 @@ public class Popup extends PolymerTemplate<Popup.PopupModel> {
             show();
         }
     }
+    
+    /**
+     * Gets modeless value from popup.
+     * 
+     * @return true if popup is modeless, false otherwise
+     */
+    public boolean isModeless() {
+      return getModel().isModeless();
+    }
+
+    /**
+     * Sets the popup to be modeless.
+     * 
+     * @param modeless true if popup should be modeless, false otherwise
+     */
+    public void setModeless(boolean modeless) {
+      getModel().setModeless(modeless);    }
 
     /**
      * This model binds properties between java(Popup) and
@@ -268,6 +285,11 @@ public class Popup extends PolymerTemplate<Popup.PopupModel> {
         void setCloseOnClick(boolean close);
 
         boolean isCloseOnClick();
+        
+        boolean isModeless();
+        
+        void setModeless(boolean modeless);      
+       
     }
 
     @DomEvent("popup-open-changed")


### PR DESCRIPTION
~~This PR depends on merge and release of https://github.com/vaadin-component-factory/vcf-popup/pull/18~~

Web-component version 1.2.8 includes fix to support modeless attribute. 

Snapshot version was updated to 2.2.6-SNAPSHOT. Also Vaadin version and Jetty version were updated.